### PR TITLE
Temporarily hide overlay and accessibility access

### DIFF
--- a/broadcast-receiver/src/main/kotlin/com/android/geto/broadcastreceiver/RevertToDefaultRunner.kt
+++ b/broadcast-receiver/src/main/kotlin/com/android/geto/broadcastreceiver/RevertToDefaultRunner.kt
@@ -19,6 +19,8 @@
 package com.android.geto.broadcastreceiver
 
 import android.content.Context
+import android.content.Intent
+import com.android.geto.common.SettingsObservationGate
 import com.android.geto.common.showRevertToDefaultToast
 import com.android.geto.domain.model.RevertToDefaultResult
 import com.android.geto.domain.usecase.RevertToDefaultUseCase
@@ -52,8 +54,25 @@ class RevertToDefaultRunner @Inject constructor(
         // pressing one would write remembered values back over the defaults just applied.
         // The observer service's own notification survives this: the system keeps a
         // foreground service's notification up regardless.
-        notificationManagerWrapper.cancelAll()
+        SettingsObservationGate.pause()
 
-        return revertToDefaultUseCase()
+        return try {
+            notificationManagerWrapper.cancelAll()
+
+            revertToDefaultUseCase()
+        } finally {
+            SettingsObservationGate.resume()
+
+            // If the optional observer service is running, reset its foreground
+            // notification after suppressing IMD's own burst of settings writes. An
+            // explicit start to an already-running service only delivers this command.
+            if (SettingsObservationGate.isRunning) {
+                context.startService(
+                    Intent()
+                        .setClassName(context, SettingsObservationGate.SERVICE_CLASS_NAME)
+                        .setAction(SettingsObservationGate.ACTION_RESET),
+                )
+            }
+        }
     }
 }

--- a/common/src/main/kotlin/com/android/geto/common/SettingsObservationGate.kt
+++ b/common/src/main/kotlin/com/android/geto/common/SettingsObservationGate.kt
@@ -1,0 +1,51 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *   Modifications Copyright 2026 soul_99 (suIMD)
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.android.geto.common
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Prevents the diagnostic settings observer from reporting changes IMD is making itself.
+ *
+ * The counter supports nested callers without letting an inner completion resume
+ * observation while an outer operation is still writing settings.
+ */
+object SettingsObservationGate {
+    const val SERVICE_CLASS_NAME = "com.android.geto.service.SettingsObserverService"
+    const val ACTION_RESET = "com.android.geto.action.RESET_SETTINGS_OBSERVER"
+
+    private val pauseCount = AtomicInteger(0)
+    private val running = AtomicBoolean(false)
+
+    val isPaused: Boolean get() = pauseCount.get() > 0
+    val isRunning: Boolean get() = running.get()
+
+    fun setRunning(value: Boolean) {
+        running.set(value)
+    }
+
+    fun pause() {
+        pauseCount.incrementAndGet()
+    }
+
+    fun resume() {
+        pauseCount.updateAndGet { count -> (count - 1).coerceAtLeast(0) }
+    }
+}

--- a/data/datastore-proto/src/main/proto/com/android/geto/data/datastore/proto/user_preferences.proto
+++ b/data/datastore-proto/src/main/proto/com/android/geto/data/datastore/proto/user_preferences.proto
@@ -169,6 +169,11 @@ message UserPreferences {
   // which is the single most common thing to misread about it.
   bool settingsManagerInfoShown = 31;
 
+  // Packages whose display-over-other-apps AppOp IMD changed from allow to ignore, mapped
+  // to "<firstInstallTime>:<uid>". Revert drops an entry if that identity changed, so an
+  // app installed later under the same package name is never granted the old app's access.
+  map<string, string> heldOverlayPackages = 32;
+
   // 9 was favouriteAppsTapAction. What a tap and a long press do is now decided by the
   // notification function rather than chosen, so there is nothing left for it to store.
   // 14 was a single global suspended-services list, replaced by the map above.

--- a/data/datastore/src/main/kotlin/com/android/geto/data/datastore/UserPreferencesDataSource.kt
+++ b/data/datastore/src/main/kotlin/com/android/geto/data/datastore/UserPreferencesDataSource.kt
@@ -90,6 +90,7 @@ class UserPreferencesDataSource @Inject constructor(private val userPreferences:
             heldAccessibilityServices = it.heldAccessibilityServicesMap.mapValues { entry ->
                 AccessibilityServicePlan.decode(entry.value)
             },
+            heldOverlayPackages = it.heldOverlayPackagesMap.toMap(),
             manualRevertTargets = ManualRevertTarget.decode(it.manualRevertTargetsList),
             notificationFunction = it.notificationFunction.asNotificationFunction(),
             revertDefaults = RevertDefaults.decode(it.revertDefaultsList),
@@ -255,6 +256,15 @@ class UserPreferencesDataSource @Inject constructor(private val userPreferences:
                 heldAccessibilityServices.putAll(
                     held.mapValues { entry -> AccessibilityServicePlan.encode(entry.value) },
                 )
+            }
+        }
+    }
+
+    suspend fun updateHeldOverlayPackages(packages: Map<String, String>) {
+        userPreferences.updateData {
+            it.copy {
+                heldOverlayPackages.clear()
+                heldOverlayPackages.putAll(packages)
             }
         }
     }

--- a/data/repository/src/main/kotlin/com/android/geto/data/repository/DefaultUserDataRepository.kt
+++ b/data/repository/src/main/kotlin/com/android/geto/data/repository/DefaultUserDataRepository.kt
@@ -110,6 +110,10 @@ class DefaultUserDataRepository @Inject constructor(
         userPreferencesDataSource.updateHeldAccessibilityServices(held = held)
     }
 
+    override suspend fun updateHeldOverlayPackages(packages: Map<String, String>) {
+        userPreferencesDataSource.updateHeldOverlayPackages(packages = packages)
+    }
+
     override suspend fun updateManualRevertTargets(targets: Set<ManualRevertTarget>) {
         userPreferencesDataSource.updateManualRevertTargets(targets = targets)
     }

--- a/domain/framework/src/main/kotlin/com/android/geto/domain/framework/PackageManagerWrapper.kt
+++ b/domain/framework/src/main/kotlin/com/android/geto/domain/framework/PackageManagerWrapper.kt
@@ -59,5 +59,8 @@ interface PackageManagerWrapper {
      */
     suspend fun getLastInstallTimes(): Map<String, Long>
 
+    /** Installation identities for the requested packages; missing packages are omitted. */
+    suspend fun getPackageIdentities(packageNames: Set<String>): Map<String, String>
+
     fun isSystem(flags: Int): Boolean
 }

--- a/domain/framework/src/main/kotlin/com/android/geto/domain/framework/ShizukuWrapper.kt
+++ b/domain/framework/src/main/kotlin/com/android/geto/domain/framework/ShizukuWrapper.kt
@@ -36,6 +36,18 @@ interface ShizukuWrapper {
     suspend fun isShizukuRunning(): Boolean
 
     /**
+     * Packages whose SYSTEM_ALERT_WINDOW AppOp is currently allowed, or null when the
+     * Shizuku shell is unavailable.
+     */
+    suspend fun getAllowedOverlayPackages(): Set<String>?
+
+    /**
+     * Changes SYSTEM_ALERT_WINDOW and returns the packages successfully changed, or null
+     * when no Shizuku shell was available. Packages are attempted independently.
+     */
+    suspend fun setOverlayPermission(packages: Set<String>, allowed: Boolean): Set<String>?
+
+    /**
      * Fires the "start Shizuku" broadcast at the Shizuku manager app.
      *
      * Two fork families are supported. thedjchi's listens for an explicit broadcast

--- a/domain/model/src/main/kotlin/com/android/geto/domain/model/AccessibilityServicePlan.kt
+++ b/domain/model/src/main/kotlin/com/android/geto/domain/model/AccessibilityServicePlan.kt
@@ -37,6 +37,9 @@ object AccessibilityServicePlan {
 
     private const val SEPARATOR = ":"
 
+    /** Hold key used by the device-wide "Settings to hide" accessibility target. */
+    const val DEVICE_WIDE_HOLD = "__device_wide_settings_to_hide__"
+
     data class Hold(
         /** The new value for enabled_accessibility_services. */
         val enabledAfter: List<String>,

--- a/domain/model/src/main/kotlin/com/android/geto/domain/model/ManualRevert.kt
+++ b/domain/model/src/main/kotlin/com/android/geto/domain/model/ManualRevert.kt
@@ -26,7 +26,7 @@ package com.android.geto.domain.model
  * remaining route is Android's own developer-options screen, which is exactly the screen
  * that is switched off.
  *
- * [globalSettingKey] is the Global setting written back to "1"; the two targets that are
+ * [globalSettingKey] is the Global setting written back to "1"; targets that are
  * not a single settings row carry null and are handled specifically.
  */
 enum class ManualRevertTarget(val globalSettingKey: String?) {
@@ -35,6 +35,7 @@ enum class ManualRevertTarget(val globalSettingKey: String?) {
     WirelessDebugging(AppSettingKeys.ADB_WIFI_ENABLED),
     AccessibilityServices(null),
     Shizuku(null),
+    DisplayOverOtherApps(null),
     ;
 
     companion object {

--- a/domain/model/src/main/kotlin/com/android/geto/domain/model/RevertDefaults.kt
+++ b/domain/model/src/main/kotlin/com/android/geto/domain/model/RevertDefaults.kt
@@ -68,6 +68,9 @@ object RevertDefaults {
         ManualRevertTarget.WirelessDebugging to false,
         ManualRevertTarget.AccessibilityServices to true,
         ManualRevertTarget.Shizuku to false,
+        // Only packages IMD previously disabled are restored, so this does not grant
+        // overlay access to anything new.
+        ManualRevertTarget.DisplayOverOtherApps to true,
     )
 
     fun encode(states: Map<ManualRevertTarget, Boolean>): List<String> =

--- a/domain/model/src/main/kotlin/com/android/geto/domain/model/SettingsToHide.kt
+++ b/domain/model/src/main/kotlin/com/android/geto/domain/model/SettingsToHide.kt
@@ -25,7 +25,7 @@ package com.android.geto.domain.model
  * says what to hide on the way in, that one says what to put back on the way out. Together
  * they replace having to write a profile for every app before any of them can be opened —
  * which was the single largest thing standing between installing this app and using it,
- * because the settings a locked-down app objects to are the same four whichever app it is.
+ * because the settings a locked-down app objects to are the same whichever app it is.
  *
  * Per-app profiles still exist and are still the more precise tool; they are what the
  * memory notification function uses. This is the answer for everyone who wants the common
@@ -43,9 +43,9 @@ object SettingsToHide {
     private const val OFF = "0"
 
     /**
-     * The four an app can actually detect, in the order the dialog lists them.
+     * The settings an app can actually detect, in the order the dialog lists them.
      *
-     * [ManualRevertTarget] carries a fifth, Shizuku, which belongs to reverting and not to
+     * [ManualRevertTarget] also carries Shizuku, which belongs to reverting and not to
      * hiding; taking a subset here rather than adding a second enum keeps one vocabulary
      * of targets across both configurations, so the dialogs and the audits line up.
      */
@@ -54,19 +54,24 @@ object SettingsToHide {
         ManualRevertTarget.UsbDebugging,
         ManualRevertTarget.WirelessDebugging,
         ManualRevertTarget.AccessibilityServices,
+        ManualRevertTarget.DisplayOverOtherApps,
     )
 
     /**
-     * All four, unlike [RevertDefaults.Default].
+     * The settings backed by WRITE_SECURE_SETTINGS default on. Overlay access is opt-in
+     * because changing AppOps requires a running Shizuku service; enabling it by default
+     * would make launches fail on otherwise correctly configured ADB-only installs.
      *
      * The two defaults differ because the risks are not symmetrical. Switching something
      * *on* that the user keeps off is a change to their device they never asked for, so
      * reverting starts conservative. Switching something off before launching an app is
      * the entire point of the app, is undone by the very next revert, and hiding only some
-     * of the four is the case that fails in a way nobody can diagnose: the app still sees
+     * of the debugging settings is the case that fails in a way nobody can diagnose: the app still sees
      * developer mode and still refuses to run.
      */
-    val Default: Map<ManualRevertTarget, Boolean> = Targets.associateWith { true }
+    val Default: Map<ManualRevertTarget, Boolean> = Targets.associateWith {
+        it != ManualRevertTarget.DisplayOverOtherApps
+    }
 
     /**
      * The order to switch things off in — the reverse of the order to switch them on in.

--- a/domain/model/src/main/kotlin/com/android/geto/domain/model/UserData.kt
+++ b/domain/model/src/main/kotlin/com/android/geto/domain/model/UserData.kt
@@ -34,6 +34,7 @@ data class UserData(
     val shizukuStartAction: String,
     val managedAccessibilityServices: List<String>,
     val heldAccessibilityServices: Map<String, List<String>>,
+    val heldOverlayPackages: Map<String, String>,
     val manualRevertTargets: Set<ManualRevertTarget>,
     val notificationFunction: NotificationFunction,
     val revertDefaults: Map<ManualRevertTarget, Boolean>,

--- a/domain/repository/src/main/kotlin/com/android/geto/domain/repository/UserDataRepository.kt
+++ b/domain/repository/src/main/kotlin/com/android/geto/domain/repository/UserDataRepository.kt
@@ -65,6 +65,8 @@ interface UserDataRepository {
 
     suspend fun updateHeldAccessibilityServices(held: Map<String, List<String>>)
 
+    suspend fun updateHeldOverlayPackages(packages: Map<String, String>)
+
     suspend fun updateManualRevertTargets(targets: Set<ManualRevertTarget>)
 
     suspend fun updateNotificationFunction(notificationFunction: NotificationFunction)

--- a/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/ApplySettingsToHideUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/ApplySettingsToHideUseCase.kt
@@ -21,6 +21,7 @@ package com.android.geto.domain.usecase
 import com.android.geto.domain.common.dispatcher.Dispatcher
 import com.android.geto.domain.common.dispatcher.GetoDispatchers
 import com.android.geto.domain.model.AppSettingsResult
+import com.android.geto.domain.model.ManualRevertTarget
 import com.android.geto.domain.model.SettingsToHide
 import com.android.geto.domain.repository.UserDataRepository
 import kotlinx.coroutines.CoroutineDispatcher
@@ -61,6 +62,19 @@ class ApplySettingsToHideUseCase @Inject constructor(
 
         val before = getManualTargetStatesUseCase()
 
+        // Overlay AppOps are changed through Shizuku. Start it before touching anything
+        // else, while the debugging transport is still available; the configured hide
+        // order will switch that transport (and therefore Shizuku) back off afterward.
+        if (wanted[ManualRevertTarget.DisplayOverOtherApps] == true &&
+            !before.isEnabled(ManualRevertTarget.Shizuku) &&
+            !setManualTargetUseCase(
+                target = ManualRevertTarget.Shizuku,
+                enabled = true,
+            )
+        ) {
+            return AppSettingsResult.Failure
+        }
+
         var failed = false
 
         for (target in SettingsToHide.HideOrder) {
@@ -69,7 +83,15 @@ class ApplySettingsToHideUseCase @Inject constructor(
             // Already off. Writing it again is not harmless: for the accessibility
             // services target a second disable would record a fresh hold over services
             // that are already held, and nothing would ever discharge the duplicate.
-            if (!before.isEnabled(target)) continue
+            // Overlay state is queried through Shizuku. A failed query reads as off in the
+            // live manager, but launch must still attempt the write so unavailable AppOps
+            // access becomes a visible Failure rather than silently leaving overlays on.
+            if (target != ManualRevertTarget.DisplayOverOtherApps &&
+                target != ManualRevertTarget.AccessibilityServices &&
+                !before.isEnabled(target)
+            ) {
+                continue
+            }
 
             if (!setManualTargetUseCase(target = target, enabled = false)) failed = true
         }

--- a/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/GetManualTargetStatesUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/GetManualTargetStatesUseCase.kt
@@ -72,6 +72,13 @@ class GetManualTargetStatesUseCase @Inject constructor(
         val enabled = ManualRevertTarget.entries.associateWith { target ->
             when (target) {
                 ManualRevertTarget.AccessibilityServices -> {
+                    if (
+                        AccessibilityServicePlan.DEVICE_WIDE_HOLD in
+                        userData.heldAccessibilityServices
+                    ) {
+                        return@associateWith false
+                    }
+
                     // The row stands for the whole managed set, so it only reads "on" when
                     // every one of them is on — see AccessibilityServicePlan.allEnabled.
                     runCatching {
@@ -86,6 +93,12 @@ class GetManualTargetStatesUseCase @Inject constructor(
                 ManualRevertTarget.Shizuku -> {
                     shizukuAvailable &&
                         runCatching { shizukuWrapper.isShizukuRunning() }.getOrDefault(false)
+                }
+
+                ManualRevertTarget.DisplayOverOtherApps -> {
+                    runCatching {
+                        shizukuWrapper.getAllowedOverlayPackages()
+                    }.getOrNull()?.isNotEmpty() == true
                 }
 
                 else -> {

--- a/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/RevertToDefaultUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/RevertToDefaultUseCase.kt
@@ -68,35 +68,93 @@ class RevertToDefaultUseCase @Inject constructor(
     }
 
     private suspend fun revert(): RevertToDefaultResult {
-        val wanted = userDataRepository.userData.first().revertDefaults
+        val userData = userDataRepository.userData.first()
+        val wanted = userData.revertDefaults
 
-        val before = getManualTargetStatesUseCase()
+        var before = getManualTargetStatesUseCase()
 
         val changed = mutableSetOf<ManualRevertTarget>()
         val failed = mutableSetOf<ManualRevertTarget>()
         val unchanged = mutableSetOf<ManualRevertTarget>()
 
-        // Declaration order, and it is load-bearing: USB debugging is meaningless with
-        // developer options off, and Shizuku cannot start without USB debugging. Working
-        // through the enum in order means each target is set up by the time the next one
-        // needs it.
-        for (target in ManualRevertTarget.entries) {
-            val enabled = wanted[target] ?: continue
-
+        suspend fun applyTarget(target: ManualRevertTarget, enabled: Boolean) {
             if (before.isEnabled(target) == enabled) {
-                unchanged += target
+                if (target !in changed) unchanged += target
 
-                continue
-            }
-
-            if (target == ManualRevertTarget.Shizuku && enabled && debuggingJustEnabled(changed)) {
-                delay(SHIZUKU_START_DELAY_MILLIS)
+                return
             }
 
             if (setManualTargetUseCase(target = target, enabled = enabled)) {
                 changed += target
+                failed -= target
+                unchanged -= target
             } else {
                 failed += target
+            }
+        }
+
+        val ordinaryTargets = listOf(
+            ManualRevertTarget.DeveloperSettings,
+            ManualRevertTarget.UsbDebugging,
+            ManualRevertTarget.WirelessDebugging,
+            ManualRevertTarget.AccessibilityServices,
+        )
+
+        for (target in ordinaryTargets) {
+            wanted[target]?.let { enabled -> applyTarget(target, enabled) }
+        }
+
+        before = getManualTargetStatesUseCase()
+
+        val overlayTarget = ManualRevertTarget.DisplayOverOtherApps
+        val overlayEnabled = wanted[overlayTarget]
+        val hasOverlayDebt = userData.heldOverlayPackages.isNotEmpty()
+        // Disabling is always attempted: a failed Shizuku query reads as off in the live
+        // state, and treating that as authoritative would silently leave overlays allowed.
+        // Enabling only restores IMD's persisted debt and cannot grant anything new.
+        val overlayNeedsWrite = overlayEnabled == false ||
+            (overlayEnabled == true && hasOverlayDebt)
+        var temporarilyStartedShizuku = false
+
+        if (overlayNeedsWrite) {
+            val shizukuWasRunning = before.isEnabled(ManualRevertTarget.Shizuku)
+
+            if (!shizukuWasRunning && debuggingJustEnabled(changed)) {
+                delay(SHIZUKU_START_DELAY_MILLIS)
+            }
+
+            val shizukuReady = if (shizukuWasRunning) {
+                true
+            } else {
+                setManualTargetUseCase(ManualRevertTarget.Shizuku, enabled = true).also {
+                    temporarilyStartedShizuku = it
+                }
+            }
+
+            if (shizukuReady &&
+                setManualTargetUseCase(overlayTarget, enabled = overlayEnabled)
+            ) {
+                changed += overlayTarget
+            } else {
+                failed += overlayTarget
+            }
+        } else if (overlayEnabled != null) {
+            unchanged += overlayTarget
+        }
+
+        before = getManualTargetStatesUseCase()
+
+        wanted[ManualRevertTarget.Shizuku]?.let { enabled ->
+            applyTarget(ManualRevertTarget.Shizuku, enabled)
+        }
+
+        if (temporarilyStartedShizuku && wanted[ManualRevertTarget.Shizuku] != true) {
+            // Starting a Shizuku fork can re-enable its debugging transport. The user's
+            // configured defaults, not that implementation detail, must be the final state.
+            before = getManualTargetStatesUseCase()
+
+            for (target in ordinaryTargets.take(3)) {
+                wanted[target]?.let { enabled -> applyTarget(target, enabled) }
             }
         }
 

--- a/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/SetManualTargetUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/SetManualTargetUseCase.kt
@@ -21,6 +21,7 @@ package com.android.geto.domain.usecase
 import com.android.geto.domain.common.dispatcher.Dispatcher
 import com.android.geto.domain.common.dispatcher.GetoDispatchers
 import com.android.geto.domain.framework.AccessibilityServicesWrapper
+import com.android.geto.domain.framework.PackageManagerWrapper
 import com.android.geto.domain.framework.SecureSettingsWrapper
 import com.android.geto.domain.framework.ShizukuWrapper
 import com.android.geto.domain.model.AccessibilityServicePlan
@@ -54,6 +55,7 @@ class SetManualTargetUseCase @Inject constructor(
     private val secureSettingsWrapper: SecureSettingsWrapper,
     private val accessibilityServicesWrapper: AccessibilityServicesWrapper,
     private val shizukuWrapper: ShizukuWrapper,
+    private val packageManagerWrapper: PackageManagerWrapper,
     private val userDataRepository: UserDataRepository,
     private val startShizukuUseCase: StartShizukuUseCase,
     @param:Dispatcher(GetoDispatchers.Default) private val defaultDispatcher: CoroutineDispatcher,
@@ -81,47 +83,145 @@ class SetManualTargetUseCase @Inject constructor(
         return when (target) {
             ManualRevertTarget.AccessibilityServices -> setAccessibilityServices(enabled = enabled)
             ManualRevertTarget.Shizuku -> setShizuku(running = enabled)
+            ManualRevertTarget.DisplayOverOtherApps -> setOverlayPermission(enabled = enabled)
             else -> false
         }
+    }
+
+    private suspend fun setOverlayPermission(enabled: Boolean): Boolean {
+        val userData = userDataRepository.userData.first()
+
+        if (enabled) {
+            val held = userData.heldOverlayPackages
+
+            if (held.isEmpty()) return true
+
+            val requestingPackages = packageManagerWrapper.getPackageIdentities(held.keys)
+            val toRestore = held.filter { (packageName, identity) ->
+                requestingPackages[packageName] == identity
+            }.keys
+
+            // An uninstalled app, or one updated to stop requesting the permission, no
+            // longer has an AppOp to restore. A replacement with a different installation
+            // identity is also dropped rather than inheriting the previous app's access.
+            val restored = shizukuWrapper.setOverlayPermission(
+                packages = toRestore,
+                allowed = true,
+            ) ?: emptySet()
+            val remaining = held.filter { (packageName, identity) ->
+                requestingPackages[packageName] == identity && packageName !in restored
+            }
+
+            if (remaining != held) {
+                userDataRepository.updateHeldOverlayPackages(remaining)
+            }
+
+            return remaining.isEmpty()
+        }
+
+        val allowedPackages = shizukuWrapper.getAllowedOverlayPackages() ?: return false
+        val requestingPackages = packageManagerWrapper.getPackageIdentities(allowedPackages)
+        val toDisable = requestingPackages.keys
+
+        if (toDisable.isEmpty()) return true
+
+        // Record the debt before the shell command. A multi-package command can fail after
+        // changing an earlier package, and retaining the full set makes a later restore safe.
+        userDataRepository.updateHeldOverlayPackages(
+            userData.heldOverlayPackages + requestingPackages.filterKeys { it in toDisable },
+        )
+
+        val disabled = shizukuWrapper.setOverlayPermission(
+            packages = toDisable,
+            allowed = false,
+        ) ?: emptySet()
+
+        // Narrow the crash-safe provisional debt to what the shell actually changed.
+        // Every candidate was allowed before this attempt, so a process death before this
+        // cleanup can only re-allow something that never stopped being allowed.
+        userDataRepository.updateHeldOverlayPackages(
+            userData.heldOverlayPackages + requestingPackages.filterKeys { it in disabled },
+        )
+
+        return disabled == toDisable
     }
 
     private suspend fun setAccessibilityServices(enabled: Boolean): Boolean {
         val userData = userDataRepository.userData.first()
 
         val held = userData.heldAccessibilityServices
+        val holdKey = AccessibilityServicePlan.DEVICE_WIDE_HOLD
 
         val currentlyEnabled = runCatching {
             accessibilityServicesWrapper.getEnabledAccessibilityServices()
         }.getOrNull() ?: return false
 
-        // Switching on covers anything still held for a target app as well as the chosen
-        // set, so one press cannot leave a service down with no record of why.
-        val after = if (enabled) {
-            AccessibilityServicePlan.enable(
-                wanted = userData.managedAccessibilityServices + held.values.flatten(),
+        if (enabled) {
+            val released = held[holdKey].orEmpty()
+            val remaining = AccessibilityServicePlan.withHold(
+                held = held,
+                componentName = holdKey,
+                services = emptyList(),
+            )
+            val plan = AccessibilityServicePlan.release(
+                released = released,
+                stillHeldByOthers = AccessibilityServicePlan.heldByOthers(
+                    held = held,
+                    exceptComponentName = holdKey,
+                ),
                 currentlyEnabled = currentlyEnabled,
             )
-        } else {
-            AccessibilityServicePlan.disable(
-                unwanted = userData.managedAccessibilityServices,
-                currentlyEnabled = currentlyEnabled,
-            )
+
+            val written = runCatching {
+                accessibilityServicesWrapper.setEnabledAccessibilityServices(plan.enabledAfter)
+            }.getOrDefault(false)
+
+            if (written && remaining != held) {
+                userDataRepository.updateHeldAccessibilityServices(held = remaining)
+            }
+
+            return written
         }
+
+        val heldByOthers = AccessibilityServicePlan.heldByOthers(
+            held = held,
+            exceptComponentName = holdKey,
+        )
+        val plan = AccessibilityServicePlan.hold(
+            // Claim services already held by a per-app profile as well as everything
+            // currently enabled. That prevents the profile's Revert from bringing one
+            // back while the device-wide restricted app is still open.
+            managed = held[holdKey].orEmpty() + currentlyEnabled + heldByOthers,
+            currentlyEnabled = currentlyEnabled,
+            heldByOthers = heldByOthers,
+        )
+
+        if (plan.held.isEmpty() && !plan.listChanged) return true
+
+        val updatedHeld = AccessibilityServicePlan.withHold(
+            held = held,
+            componentName = holdKey,
+            // A second device-wide launch must extend the existing debt rather than
+            // replacing it. Services from the first launch are already off, so hold()
+            // cannot rediscover them from the live enabled list.
+            services = held[holdKey].orEmpty() + plan.held,
+        )
+
+        // Persist before writing so process death cannot leave a service disabled with no
+        // record capable of restoring it.
+        userDataRepository.updateHeldAccessibilityServices(held = updatedHeld)
 
         val written = runCatching {
-            accessibilityServicesWrapper.setEnabledAccessibilityServices(after)
+            accessibilityServicesWrapper.setEnabledAccessibilityServices(
+                plan.enabledAfter,
+            )
         }.getOrDefault(false)
 
-        if (!written) return false
-
-        // The holds describe services this app switched off on some app's behalf. Turning
-        // them all back on here discharges that debt; turning them off by hand does not
-        // create one, because nothing is waiting to put them back.
-        if (enabled && held.isNotEmpty()) {
-            userDataRepository.updateHeldAccessibilityServices(held = emptyMap())
+        if (!written) {
+            userDataRepository.updateHeldAccessibilityServices(held = held)
         }
 
-        return true
+        return written
     }
 
     private suspend fun setShizuku(running: Boolean): Boolean {

--- a/feature/apps/src/main/kotlin/com/android/geto/feature/apps/dialog/AndroidSettingsManagerDialog.kt
+++ b/feature/apps/src/main/kotlin/com/android/geto/feature/apps/dialog/AndroidSettingsManagerDialog.kt
@@ -87,7 +87,6 @@ internal fun AndroidSettingsManagerDialog(
     busy: Boolean,
     shizukuStarting: Boolean,
     shizukuStartFailed: Boolean,
-    accessibilityManaged: Boolean,
     /** Null while the stored answer is still being read; see the ViewModel. */
     infoShown: Boolean? = true,
     onInfoShown: () -> Unit = {},
@@ -96,7 +95,6 @@ internal fun AndroidSettingsManagerDialog(
     onOpen: (ManualRevertTarget) -> Unit,
     onRevertToDefault: () -> Unit,
     onOpenRevertConfiguration: () -> Unit,
-    onAccessibilityUnmanaged: () -> Unit,
 ) {
     var showShizukuHelp by remember { mutableStateOf(false) }
 
@@ -172,15 +170,6 @@ internal fun AndroidSettingsManagerDialog(
             ManualRevertTarget.entries.forEach { target ->
                 val isShizuku = target == ManualRevertTarget.Shizuku
 
-                // Nothing is managed, so there is nothing this switch could do. Shown off
-                // and greyed rather than hidden: the row is what tells the user the
-                // capability exists and is unconfigured, and its own note points at where
-                // to configure it. Forced off regardless of the revert configuration --
-                // a configuration saying "restore accessibility services" cannot restore
-                // an empty list, and a switch reading on would be describing nothing.
-                val accessibilityUnmanaged =
-                    target == ManualRevertTarget.AccessibilityServices && !accessibilityManaged
-
                 TargetRow(
                     target = target,
                     // Only ever true for the Shizuku row: it is the one target the app can
@@ -191,16 +180,15 @@ internal fun AndroidSettingsManagerDialog(
                     // the two to show for a beat: it invites a press that helps, where a
                     // wrong "on" invites the user to walk away from a device still locked
                     // down.
-                    enabled = states.isEnabled(target) && !accessibilityUnmanaged,
+                    enabled = states.isEnabled(target),
                     // Shizuku is the only row that can be switched off in the sense of
                     // "there is nothing here to control".
                     // Locked while an attempt is in flight. The switch already reads on and
                     // the outcome is a few seconds away; letting it be pressed again would
                     // queue a second attempt against a service that is still deciding.
-                    usable = !busy && !accessibilityUnmanaged &&
+                    usable = !busy &&
                         (!isShizuku || (states.shizukuAvailable && !shizukuStarting)),
                     onClickWhenUnusable = when {
-                        accessibilityUnmanaged -> onAccessibilityUnmanaged
                         isShizuku -> {
                             { showShizukuHelp = true }
                         }
@@ -346,7 +334,7 @@ private fun TargetRow(
             // it means.
             if (target == ManualRevertTarget.AccessibilityServices) {
                 Text(
-                    text = stringResource(R.string.settings_manager_accessibility_note),
+                    text = stringResource(R.string.settings_manager_accessibility_all_note),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -500,6 +488,7 @@ private fun ShizukuHelpDialog(
 private val ManualRevertTarget.opensSomewhere: Boolean
     get() = this == ManualRevertTarget.DeveloperSettings ||
         this == ManualRevertTarget.AccessibilityServices ||
+        this == ManualRevertTarget.DisplayOverOtherApps ||
         this == ManualRevertTarget.Shizuku
 
 @Composable
@@ -509,5 +498,5 @@ internal fun ManualRevertTarget.getTitle(): String = when (this) {
     ManualRevertTarget.WirelessDebugging -> stringResource(R.string.revert_wireless_debugging)
     ManualRevertTarget.AccessibilityServices -> stringResource(R.string.revert_accessibility)
     ManualRevertTarget.Shizuku -> stringResource(R.string.revert_shizuku)
+    ManualRevertTarget.DisplayOverOtherApps -> stringResource(R.string.revert_display_over_other_apps)
 }
-

--- a/feature/apps/src/main/kotlin/com/android/geto/feature/apps/manager/SettingsManagerRoute.kt
+++ b/feature/apps/src/main/kotlin/com/android/geto/feature/apps/manager/SettingsManagerRoute.kt
@@ -59,8 +59,6 @@ fun SettingsManagerRoute(
 
     val shizukuStartFailed by viewModel.shizukuStartFailed.collectAsStateWithLifecycle()
 
-    val accessibilityManaged by viewModel.accessibilityManaged.collectAsStateWithLifecycle()
-
     val infoShown by viewModel.infoShown.collectAsStateWithLifecycle()
 
     // Polling runs only while this is composed. DisposableEffect rather than
@@ -107,14 +105,6 @@ fun SettingsManagerRoute(
 
             context.openRevertConfiguration()
         },
-        onAccessibilityUnmanaged = {
-            Toast.makeText(
-                context,
-                R.string.settings_manager_accessibility_unmanaged,
-                Toast.LENGTH_LONG,
-            ).show()
-        },
-        accessibilityManaged = accessibilityManaged,
     )
 }
 
@@ -134,6 +124,10 @@ internal fun Context.openTarget(target: ManualRevertTarget, shizukuPackage: Stri
 
         ManualRevertTarget.AccessibilityServices -> {
             Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
+        }
+
+        ManualRevertTarget.DisplayOverOtherApps -> {
+            Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION)
         }
 
         ManualRevertTarget.Shizuku -> {

--- a/feature/apps/src/main/kotlin/com/android/geto/feature/apps/manager/SettingsManagerViewModel.kt
+++ b/feature/apps/src/main/kotlin/com/android/geto/feature/apps/manager/SettingsManagerViewModel.kt
@@ -103,22 +103,6 @@ class SettingsManagerViewModel @Inject constructor(
         )
 
     /**
-     * Whether any accessibility service has been picked for this app to manage.
-     *
-     * The manager's accessibility switch governs that chosen set and nothing else, so with
-     * the set empty there is no state for it to be in. Read here rather than inferred from
-     * the polled row state, because "no services managed" and "the managed services are
-     * currently off" look identical from outside and mean opposite things.
-     */
-    val accessibilityManaged = userDataRepository.userData
-        .map { it.managedAccessibilityServices.isNotEmpty() }
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = false,
-        )
-
-    /**
      * Whether the manager has already explained itself, or null while that is still being
      * read.
      *

--- a/feature/apps/src/main/res/values/strings.xml
+++ b/feature/apps/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
     <string name="got_it">Got it</string>
     <string name="settings_manager_open">Open %1$s</string>
     <string name="settings_manager_accessibility_note">only services selected in the IMD app settings are managed</string>
+    <string name="settings_manager_accessibility_all_note">switching this off temporarily disables every enabled accessibility service; switching it on restores only services IMD held</string>
     <string name="settings_manager_enable_developer_options">Please enable developer options first</string>
     <string name="settings_manager_cannot_open">Could not open that screen on this device</string>
     <string name="settings_manager_no_shizuku">No Shizuku app found — set the package name in Settings</string>
@@ -90,6 +91,7 @@
     <string name="revert_wireless_debugging">Wireless debugging</string>
     <string name="revert_accessibility">Accessibility services</string>
     <string name="revert_shizuku">Shizuku service</string>
+    <string name="revert_display_over_other_apps">Display over other apps</string>
     <string name="applied_settings_no_permission">Grant WRITE_SECURE_SETTINGS first — see the setup screen</string>
     <string name="settings_manager_shizuku_failed">Failed to start shizuku service on last attempt, please check shizuku app settings and IMD shizuku configuration</string>
     <string name="settings_manager_shizuku_failed_open">Why the Shizuku service did not start</string>

--- a/feature/settings/src/main/kotlin/com/android/geto/feature/settings/dialog/RevertDefaultsDialog.kt
+++ b/feature/settings/src/main/kotlin/com/android/geto/feature/settings/dialog/RevertDefaultsDialog.kt
@@ -26,6 +26,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -72,6 +74,7 @@ internal fun RevertDefaultsDialog(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
                 .padding(10.dp),
         ) {
             Text(
@@ -111,7 +114,7 @@ internal fun RevertDefaultsDialog(
 
             RevertDefaultRow(
                 label = stringResource(R.string.revert_defaults_accessibility_services),
-                note = stringResource(R.string.revert_defaults_accessibility_note),
+                note = stringResource(R.string.revert_defaults_accessibility_all_note),
                 checked = draft[ManualRevertTarget.AccessibilityServices] == true,
                 onCheckedChange = { toggle(ManualRevertTarget.AccessibilityServices, it) },
             )
@@ -121,6 +124,13 @@ internal fun RevertDefaultsDialog(
                 note = stringResource(R.string.revert_defaults_shizuku_note),
                 checked = draft[ManualRevertTarget.Shizuku] == true,
                 onCheckedChange = { toggle(ManualRevertTarget.Shizuku, it) },
+            )
+
+            RevertDefaultRow(
+                label = stringResource(R.string.revert_defaults_display_over_other_apps),
+                note = stringResource(R.string.revert_defaults_overlay_note),
+                checked = draft[ManualRevertTarget.DisplayOverOtherApps] == true,
+                onCheckedChange = { toggle(ManualRevertTarget.DisplayOverOtherApps, it) },
             )
 
             Row(

--- a/feature/settings/src/main/kotlin/com/android/geto/feature/settings/dialog/SettingsToHideDialog.kt
+++ b/feature/settings/src/main/kotlin/com/android/geto/feature/settings/dialog/SettingsToHideDialog.kt
@@ -124,9 +124,16 @@ internal fun SettingsToHideDialog(
                 // caveat is about which services this app manages at all, so it is the
                 // same fact in both places and must not be able to drift.
                 label = stringResource(R.string.revert_defaults_accessibility_services),
-                note = stringResource(R.string.revert_defaults_accessibility_note),
+                note = stringResource(R.string.settings_to_hide_accessibility_note),
                 checked = draft[ManualRevertTarget.AccessibilityServices] == true,
                 onCheckedChange = { toggle(ManualRevertTarget.AccessibilityServices, it) },
+            )
+
+            SettingToHideRow(
+                label = stringResource(R.string.revert_defaults_display_over_other_apps),
+                note = stringResource(R.string.settings_to_hide_overlay_note),
+                checked = draft[ManualRevertTarget.DisplayOverOtherApps] == true,
+                onCheckedChange = { toggle(ManualRevertTarget.DisplayOverOtherApps, it) },
             )
 
             Spacer(modifier = Modifier.height(8.dp))

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -127,6 +127,8 @@
     <string name="settings_to_hide_description">These settings are hidden when you launch an app.</string>
     <string name="settings_to_hide_summary">%1$d of %2$d switched on</string>
     <string name="settings_to_hide_usb_note">stopping USB debugging will also kill Shizuku service(if running), please configure Shizuku settings under IMD app to restart the Shizuku service after Revert</string>
+    <string name="settings_to_hide_accessibility_note">every currently enabled accessibility service is temporarily disabled and exactly those services are restored on Revert</string>
+    <string name="settings_to_hide_overlay_note">requires Shizuku to be running; every app currently allowed to display over other apps is temporarily disabled</string>
     <string name="settings_to_hide_info_per_app">If you want to hide different settings per individual app, please use memory function in IMD settings &gt; Advanced &gt; Notification function</string>
     <string name="settings_to_hide_info_all">Hiding only developer settings does not turn off USB and wireless debugging, and some apps might still detect that as developer settings turned on, so it is recommended to select all three</string>
     <string name="settings_to_hide_info_shizuku">to hide Shizuku from apps use the Hide Shizuku from other apps function within the Shizuku app.</string>
@@ -138,8 +140,11 @@
     <string name="revert_defaults_wireless_debugging">Wireless debugging</string>
     <string name="revert_defaults_accessibility_services">Accessibility services</string>
     <string name="revert_defaults_accessibility_note">only services selected in the IMD app settings are managed</string>
+    <string name="revert_defaults_accessibility_all_note">restores only the accessibility services IMD disabled during device-wide hiding</string>
     <string name="revert_defaults_shizuku">Shizuku service</string>
     <string name="revert_defaults_shizuku_note">Depending on which method Shizuku uses to start the service it will re-enable either one of USB debugging or wireless debugging, which it also needs to keep the Shizuku service running</string>
+    <string name="revert_defaults_display_over_other_apps">Display over other apps</string>
+    <string name="revert_defaults_overlay_note">restores only the apps IMD previously disabled; Shizuku must be running</string>
 
     <!-- suIMD: the setup help, shown on onboarding page two and from Settings -->
     <string name="help_button">Help (readme)</string>

--- a/framework/package-manager/src/main/kotlin/com/android/geto/framework/packagemanager/DefaultPackageManagerWrapper.kt
+++ b/framework/package-manager/src/main/kotlin/com/android/geto/framework/packagemanager/DefaultPackageManagerWrapper.kt
@@ -161,5 +161,26 @@ internal class DefaultPackageManagerWrapper @Inject constructor(
         packages.associate { it.packageName to it.lastUpdateTime }
     }
 
+    override suspend fun getPackageIdentities(packageNames: Set<String>): Map<String, String> =
+        withContext(ioDispatcher) {
+            packageNames.mapNotNull { packageName ->
+                val packageInfo = runCatching {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        packageManager.getPackageInfo(
+                            packageName,
+                            PackageManager.PackageInfoFlags.of(0),
+                        )
+                    } else {
+                        @Suppress("DEPRECATION")
+                        packageManager.getPackageInfo(packageName, 0)
+                    }
+                }.getOrNull() ?: return@mapNotNull null
+
+                    val uid = packageInfo.applicationInfo?.uid ?: -1
+
+                    packageInfo.packageName to "${packageInfo.firstInstallTime}:$uid"
+            }.toMap()
+        }
+
     override fun isSystem(flags: Int): Boolean = (flags and (ApplicationInfo.FLAG_SYSTEM or ApplicationInfo.FLAG_UPDATED_SYSTEM_APP)) != 0
 }

--- a/framework/shizuku/src/main/kotlin/com/android/geto/framework/shizuku/DefaultShizukuWrapper.kt
+++ b/framework/shizuku/src/main/kotlin/com/android/geto/framework/shizuku/DefaultShizukuWrapper.kt
@@ -46,6 +46,17 @@ internal class DefaultShizukuWrapper @Inject constructor(
             ShizukuPermission.grantWriteSecureSettings(packageName = packageName)
         }
 
+    override suspend fun getAllowedOverlayPackages(): Set<String>? = withContext(ioDispatcher) {
+        ShizukuPermission.getAllowedOverlayPackages()
+    }
+
+    override suspend fun setOverlayPermission(
+        packages: Set<String>,
+        allowed: Boolean,
+    ): Set<String>? = withContext(ioDispatcher) {
+        ShizukuPermission.setOverlayPermission(packages = packages, allowed = allowed)
+    }
+
     override suspend fun startShizuku(
         packageName: String,
         action: String,

--- a/framework/shizuku/src/main/kotlin/com/android/geto/framework/shizuku/ShizukuPermission.kt
+++ b/framework/shizuku/src/main/kotlin/com/android/geto/framework/shizuku/ShizukuPermission.kt
@@ -30,6 +30,8 @@ private const val TAG = "ShizukuPermission"
 /** Any int; it only has to match between the request and the callback. */
 private const val REQUEST_CODE = 4919
 
+private val PACKAGE_NAME = Regex("""[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)+""")
+
 /**
  * Everything that talks to the Shizuku client library, kept in one file.
  *
@@ -60,6 +62,45 @@ internal object ShizukuPermission {
         )
 
         return if (granted) ShizukuGrant.Granted else ShizukuGrant.Failed
+    }
+
+    suspend fun getAllowedOverlayPackages(): Set<String>? {
+        if (!isRunning() || !ensurePermission()) return null
+
+        val output = runShellForOutput(
+            "cmd appops query-op --user current SYSTEM_ALERT_WINDOW allow",
+        ) ?: return null
+        val allowed = output.lineSequence()
+            .map(String::trim)
+            .filter(PACKAGE_NAME::matches)
+            .toSet()
+
+        return allowed
+    }
+
+    suspend fun setOverlayPermission(
+        packages: Set<String>,
+        allowed: Boolean,
+    ): Set<String>? {
+        if (packages.isEmpty()) return emptySet()
+        if (!packages.all(PACKAGE_NAME::matches)) return null
+        if (!isRunning() || !ensurePermission()) return null
+
+        val mode = if (allowed) "allow" else "ignore"
+        val command = packages.joinToString(separator = ";") { packageName ->
+            "cmd appops set --user current $packageName SYSTEM_ALERT_WINDOW $mode"
+        }
+
+        if (!runShell(command)) return emptySet()
+
+        val allowedAfter = getAllowedOverlayPackages() ?: return null
+        val changed = if (allowed) {
+            packages.intersect(allowedAfter)
+        } else {
+            packages - allowedAfter
+        }
+
+        return changed
     }
 
     private suspend fun ensurePermission(): Boolean {
@@ -112,6 +153,28 @@ internal object ShizukuPermission {
      * disappears this returns false and the ADB instructions on the same screen still work.
      */
     private fun runShell(command: String): Boolean = runCatching {
+        runShellProcess(command).waitFor() == 0
+    }.getOrElse {
+        Log.w(TAG, "Shizuku shell failed", it)
+
+        false
+    }
+
+    private fun runShellForOutput(command: String): String? = runCatching {
+        // Some OEM cmd services write successful query output to stderr. Merge it into
+        // stdout inside the remote shell because Shizuku's reflected Process exposes the
+        // two streams separately.
+        val process = runShellProcess("$command 2>&1")
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+
+        if (process.waitFor() == 0) output else null
+    }.getOrElse {
+        Log.w(TAG, "Shizuku shell failed", it)
+
+        null
+    }
+
+    private fun runShellProcess(command: String): Process {
         val newProcess = Shizuku::class.java.getDeclaredMethod(
             "newProcess",
             Array<String>::class.java,
@@ -121,17 +184,11 @@ internal object ShizukuPermission {
 
         newProcess.isAccessible = true
 
-        val process = newProcess.invoke(
+        return newProcess.invoke(
             null,
             arrayOf("sh", "-c", command),
             null,
             null,
         ) as Process
-
-        process.waitFor() == 0
-    }.getOrElse {
-        Log.w(TAG, "Shizuku shell failed", it)
-
-        false
     }
 }

--- a/service/src/main/kotlin/com/android/geto/service/SettingsObserverService.kt
+++ b/service/src/main/kotlin/com/android/geto/service/SettingsObserverService.kt
@@ -33,6 +33,7 @@ import android.provider.Settings
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import com.android.geto.common.AppLocale
+import com.android.geto.common.SettingsObservationGate
 import com.android.geto.framework.notificationmanager.AndroidNotificationManagerWrapper
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -58,6 +59,8 @@ class SettingsObserverService : Service() {
     private val observer = object : ContentObserver(Handler(Looper.getMainLooper())) {
         override fun onChange(selfChange: Boolean, uri: Uri?) {
             super.onChange(selfChange, uri)
+
+            if (SettingsObservationGate.isPaused) return
 
             val category = when {
                 uri.toString().startsWith(Settings.System.CONTENT_URI.toString()) -> getString(
@@ -107,6 +110,7 @@ class SettingsObserverService : Service() {
         _isRunning.update {
             true
         }
+        SettingsObservationGate.setRunning(true)
 
         ServiceCompat.startForeground(
             this,
@@ -153,6 +157,16 @@ class SettingsObserverService : Service() {
 
                 return START_NOT_STICKY
             }
+
+            SettingsObservationGate.ACTION_RESET -> {
+                androidNotificationManagerWrapper.notify(
+                    id = NOTIFICATION_ID,
+                    notification = getNotification(
+                        title = getString(R.string.settings_observer),
+                        text = getString(R.string.waiting_for_changes),
+                    ),
+                )
+            }
         }
 
         return START_STICKY
@@ -164,6 +178,7 @@ class SettingsObserverService : Service() {
         _isRunning.update {
             false
         }
+        SettingsObservationGate.setRunning(false)
 
         contentResolver.unregisterContentObserver(observer)
     }

--- a/tools/host-tests/DomainLogicTests.kt
+++ b/tools/host-tests/DomainLogicTests.kt
@@ -366,6 +366,61 @@ private fun accessibilityRoundTripTests() {
     enabled2 = ra2.enabledAfter
     checkEquals("A reverted last: everything is back", original.toSet(), enabled2.toSet())
     check("reverse order also empties the record", record2.isEmpty())
+
+    // 21. A device-wide hold claims every enabled service and anything already held by a
+    // per-app profile. Releasing the profile first must restore nothing; releasing the
+    // device-wide hold last restores the exact original set.
+    val deviceWide = AccessibilityServicePlan.DEVICE_WIDE_HOLD
+    var record3 = mapOf(appA to listOf(SWIPE))
+    var enabled3 = listOf(TALKBACK, TASKER)
+    val globalHold = AccessibilityServicePlan.hold(
+        managed = enabled3 + AccessibilityServicePlan.heldByOthers(record3, deviceWide),
+        currentlyEnabled = enabled3,
+        heldByOthers = AccessibilityServicePlan.heldByOthers(record3, deviceWide),
+    )
+    record3 = AccessibilityServicePlan.withHold(record3, deviceWide, globalHold.held)
+    enabled3 = globalHold.enabledAfter
+    checkEquals("device-wide hold disables every enabled service", emptyList<String>(), enabled3)
+    checkEquals(
+        "device-wide hold also claims services already held per app",
+        setOf(TALKBACK, TASKER, SWIPE),
+        record3[deviceWide]?.toSet(),
+    )
+
+    val profileRelease = AccessibilityServicePlan.release(
+        released = record3[appA].orEmpty(),
+        stillHeldByOthers = AccessibilityServicePlan.heldByOthers(record3, appA),
+        currentlyEnabled = enabled3,
+    )
+    record3 = AccessibilityServicePlan.withHold(record3, appA, emptyList())
+    enabled3 = profileRelease.enabledAfter
+    checkEquals("profile revert cannot pierce device-wide hold", emptyList<String>(), enabled3)
+
+    val globalRelease = AccessibilityServicePlan.release(
+        released = record3[deviceWide].orEmpty(),
+        stillHeldByOthers = AccessibilityServicePlan.heldByOthers(record3, deviceWide),
+        currentlyEnabled = enabled3,
+    )
+    enabled3 = globalRelease.enabledAfter
+    checkEquals(
+        "device-wide revert restores the exact original services",
+        setOf(TALKBACK, TASKER, SWIPE),
+        enabled3.toSet(),
+    )
+
+    // A later launch can find a newly enabled service, but must retain the debt from the
+    // first launch even though those earlier services are no longer in the live list.
+    val previousDebt = listOf(TALKBACK, TASKER)
+    val laterHold = AccessibilityServicePlan.hold(
+        managed = previousDebt + listOf(BIXBY),
+        currentlyEnabled = listOf(BIXBY),
+        heldByOthers = emptyList(),
+    )
+    checkEquals(
+        "repeated device-wide holds merge old and new restoration debt",
+        setOf(TALKBACK, TASKER, BIXBY),
+        (previousDebt + laterHold.held).toSet(),
+    )
 }
 
 private fun favouriteOrderingTests() {
@@ -623,7 +678,7 @@ private fun appListOrderingTests() {
 private fun manualRevertTests() {
     checkEquals(
         "default selection is every target",
-        5,
+        6,
         ManualRevertTarget.Default.size,
     )
     checkEquals(
@@ -632,8 +687,12 @@ private fun manualRevertTests() {
         ManualRevertTarget.entries.mapNotNull { it.globalSettingKey },
     )
     checkEquals(
-        "accessibility and shizuku are not a single settings row",
-        listOf(ManualRevertTarget.AccessibilityServices, ManualRevertTarget.Shizuku),
+        "special targets are not a single settings row",
+        listOf(
+            ManualRevertTarget.AccessibilityServices,
+            ManualRevertTarget.Shizuku,
+            ManualRevertTarget.DisplayOverOtherApps,
+        ),
         ManualRevertTarget.entries.filter { it.globalSettingKey == null },
     )
 
@@ -862,6 +921,7 @@ private fun userData(
     shizukuStartAction = startAction,
     managedAccessibilityServices = emptyList(),
     heldAccessibilityServices = emptyMap(),
+    heldOverlayPackages = emptyMap(),
     manualRevertTargets = emptySet(),
     notificationFunction = NotificationFunction.Default,
     revertDefaults = RevertDefaults.Default,
@@ -1118,10 +1178,9 @@ private fun accessibilityLiveStateTests() {
  * rule it enforces between two of its rows.
  */
 private fun revertDefaultsTests() {
-    // 45. Never configured falls back to accessibility services alone. Every other target
-    // is a debugging surface, and a Revert that switches those on can leave a device more
-    // open than the person pressing the button realised. Changed in v1.6.6; these assertions
-    // are what stops the old, wider default creeping back in.
+    // 45. Never configured falls back to accessibility services and restoring overlay
+    // permissions IMD previously disabled. The latter cannot grant anything new because
+    // the implementation only replays its held package set.
     checkEquals(
         "an empty configuration falls back to the default",
         RevertDefaults.Default,
@@ -1143,8 +1202,8 @@ private fun revertDefaultsTests() {
         RevertDefaults.Default[ManualRevertTarget.Shizuku],
     )
     checkEquals(
-        "accessibility services is the only target on by default",
-        1,
+        "only accessibility and held overlay permissions are restored by default",
+        2,
         RevertDefaults.Default.count { it.value },
     )
     checkEquals(
@@ -1156,6 +1215,11 @@ private fun revertDefaultsTests() {
         "wireless debugging is off by default",
         false,
         RevertDefaults.Default[ManualRevertTarget.WirelessDebugging],
+    )
+    checkEquals(
+        "held overlay permissions are restored by default",
+        true,
+        RevertDefaults.Default[ManualRevertTarget.DisplayOverOtherApps],
     )
     check(
         "the default covers every target, so decode can never be missing one",
@@ -1169,6 +1233,7 @@ private fun revertDefaultsTests() {
         ManualRevertTarget.WirelessDebugging to false,
         ManualRevertTarget.AccessibilityServices to true,
         ManualRevertTarget.Shizuku to false,
+        ManualRevertTarget.DisplayOverOtherApps to true,
     )
     checkEquals(
         "encode writes one entry per target",
@@ -1214,7 +1279,7 @@ private fun revertDefaultsTests() {
     checkEquals(
         "the encoding has no cross-target rule left to enforce",
         listOf("DeveloperSettings=0", "UsbDebugging=1", "WirelessDebugging=0",
-               "AccessibilityServices=1", "Shizuku=0"),
+               "AccessibilityServices=1", "Shizuku=0", "DisplayOverOtherApps=1"),
         RevertDefaults.encode(
             mapOf(
                 ManualRevertTarget.DeveloperSettings to false,
@@ -1222,6 +1287,7 @@ private fun revertDefaultsTests() {
                 ManualRevertTarget.WirelessDebugging to false,
                 ManualRevertTarget.AccessibilityServices to true,
                 ManualRevertTarget.Shizuku to false,
+                ManualRevertTarget.DisplayOverOtherApps to true,
             ),
         ),
     )
@@ -1234,6 +1300,7 @@ private fun revertDefaultsTests() {
         ManualRevertTarget.WirelessDebugging to true,
         ManualRevertTarget.AccessibilityServices to false,
         ManualRevertTarget.Shizuku to true,
+        ManualRevertTarget.DisplayOverOtherApps to true,
     )
     checkEquals(
         "Shizuku on with USB debugging off round-trips",
@@ -1260,8 +1327,8 @@ private fun revertDefaultsTests() {
  * "Settings to hide" — the device-wide configuration applied on the way into any app.
  *
  * Its rules differ from [RevertDefaults] in two ways that are easy to get wrong by copying
- * one from the other, so both are pinned here: it covers four targets rather than five, and
- * it defaults to all of them on rather than to a conservative subset.
+ * one from the other, so both are pinned here: Shizuku is excluded, and overlay access is
+ * opt-in because it requires a live Shizuku shell.
  */
 private fun settingsToHideTests() {
     // 51. Shizuku is not a target. It is not a setting an app reads, and hiding it belongs
@@ -1271,19 +1338,18 @@ private fun settingsToHideTests() {
         "Shizuku is not one of the targets",
         ManualRevertTarget.Shizuku !in SettingsToHide.Targets,
     )
-    checkEquals("there are exactly four targets", 4, SettingsToHide.Targets.size)
+    checkEquals("there are exactly five targets", 5, SettingsToHide.Targets.size)
 
-    // 52. All four on by default, unlike the revert configuration. Hiding only some of them
-    // is the case that fails without any way to diagnose it: the app still sees developer
-    // mode and still refuses to run, having changed the device for nothing.
+    // 52. Secure-setting targets remain on by default. Overlay access is opt-in because an
+    // ADB-only install has no AppOps shell and must continue to launch apps successfully.
     checkEquals(
         "an empty configuration falls back to the default",
         SettingsToHide.Default,
         SettingsToHide.decode(emptyList()),
     )
     check(
-        "every target is hidden by default",
-        SettingsToHide.Default.values.all { it },
+        "display-over-other-apps hiding is opt-in",
+        SettingsToHide.Default[ManualRevertTarget.DisplayOverOtherApps] == false,
     )
     checkEquals(
         "the default covers every target, so decode can never be missing one",
@@ -1311,6 +1377,7 @@ private fun settingsToHideTests() {
         ManualRevertTarget.UsbDebugging to false,
         ManualRevertTarget.WirelessDebugging to true,
         ManualRevertTarget.AccessibilityServices to false,
+        ManualRevertTarget.DisplayOverOtherApps to true,
     )
     checkEquals(
         "encode writes one entry per target",


### PR DESCRIPTION
## What changed

- Added **Display over other apps** as a device-wide setting IMD can temporarily hide.
- Temporarily disables every currently enabled accessibility service
- Records exactly which overlay permissions and accessibility services IMD changed, then restores only those items on Revert.
- Starts Shizuku automatically when overlay AppOps access is needed, batches AppOps changes, scopes them to the current Android user, and verifies the resulting state.
- Added both controls to Settings to hide, Revert defaults, and the live services manager.
- Prevented the optional Settings Observer from flooding its notification with IMD's own Revert changes.

## Why

Some banking and restricted apps refuse to run while any app can display over other apps or while accessibility services are enabled. IMD previously handled developer/debugging settings and selected accessibility services, but it did not cover these checks comprehensively or restore overlay access safely.

## Result

Launching a restricted app through IMD now temporarily removes the detectable overlay and accessibility access. Revert restores the user's previous state without granting access to new or replaced apps, and repeated launches preserve all restoration debt until Revert completes.

## Validation

- Built the debug APK successfully.
- Passed all 199 host assertions.
- Verified on a HyperOS device that the banking app opens after hiding permissions and that Revert restores overlay access.